### PR TITLE
feat: allow children views, remove gestures

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,12 @@ import React, { useState } from "react";
 import { Text, View } from "react-native";
 
 export default function App() {
-  const [motionEvent, setMotionEvent] = useState<MotionEventPayload | null>(null);
-  const [gestureEvent, setGestureEvent] = useState<GestureEventPayload | null>(null);
+  const [motionEvent, setMotionEvent] = useState<MotionEventPayload | null>(
+    null
+  );
+  const [gestureEvent, setGestureEvent] = useState<GestureEventPayload | null>(
+    null
+  );
   const [targetFPS, setTargetFPS] = useState(30);
 
   const handleMotionEvent = (event: { nativeEvent: MotionEventPayload }) => {
@@ -66,4 +70,3 @@ export default function App() {
 - Capture all types of motion events in a simple and efficient way.
 - Easy to use in Expo projects.
 - Written in TypeScript for better developer experience and type safety.
-

--- a/android/src/main/java/expo/modules/motionevent/MotionEventModule.kt
+++ b/android/src/main/java/expo/modules/motionevent/MotionEventModule.kt
@@ -7,14 +7,15 @@ class MotionEventModule : Module() {
   override fun definition() = ModuleDefinition {
     Name("MotionEvent")
 
-    Events("onMotionEvent", "onGestureEvent")
+    Events("onMotionEvent")
 
     View(MotionEventView::class) {
-      Events("onMotionEvent", "onGestureEvent")
+      Events("onMotionEvent")
 
-      Prop(name = "targetFPS") { view, value: Int ->
+      Prop("targetFPS") { view: MotionEventView, value: Int ->
         view.setTargetFPS(value)
       }
     }
   }
 }
+

--- a/android/src/main/java/expo/modules/motionevent/MotionEventView.kt
+++ b/android/src/main/java/expo/modules/motionevent/MotionEventView.kt
@@ -1,36 +1,40 @@
 package expo.modules.motionevent
 
 import android.content.Context
-import android.view.GestureDetector
 import android.view.MotionEvent
 import android.view.VelocityTracker
+import android.view.View
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.viewevent.EventDispatcher
 import expo.modules.kotlin.views.ExpoView
-import kotlin.math.hypot
 
 class MotionEventView(context: Context, appContext: AppContext) : ExpoView(context, appContext) {
   private val onMotionEvent by EventDispatcher()
-  private val onGestureEvent by EventDispatcher()
   private val velocityTracker = VelocityTracker.obtain()
-  private val gestureDetector: GestureDetector
-
   private var targetFPS: Int = 60
   private var lastEventTime: Long = 0
- 
-  init {
-    isFocusable = true
-    isClickable = true
-    setLayerType(LAYER_TYPE_HARDWARE, null)
 
-    gestureDetector = GestureDetector(context, GestureListener())
+  init {
+    val touchView = View(context).also {
+      it.layoutParams = LayoutParams(
+        LayoutParams.MATCH_PARENT,
+        LayoutParams.MATCH_PARENT
+      )
+      it.setOnTouchListener { _, event ->
+        // Handle touch event here but don't intercept it if it's meant for child views
+        handleTouchEvent(event)
+        false
+      }
+    }
+
+    addView(touchView)
   }
 
   fun setTargetFPS(fps: Int) {
     targetFPS = fps.coerceAtLeast(1)
   }
 
-  override fun onTouchEvent(event: MotionEvent): Boolean {
+  private fun handleTouchEvent(event: MotionEvent) {
     val currentTime = System.currentTimeMillis()
     val frameInterval = 1000 / targetFPS
 
@@ -40,55 +44,63 @@ class MotionEventView(context: Context, appContext: AppContext) : ExpoView(conte
       velocityTracker.computeCurrentVelocity(1000)
       onMotionEvent(createEventData(event))
     }
-
-    return gestureDetector.onTouchEvent(event) || super.onTouchEvent(event)
   }
 
-  private inner class GestureListener : GestureDetector.SimpleOnGestureListener() {
-    override fun onSingleTapConfirmed(e: MotionEvent): Boolean {
-      onGestureEvent(mapOf("type" to "tap", "x" to e.x, "y" to e.y))
-      return true
+  private fun createEventData(event: MotionEvent): Map<String, Any> {
+    val pointerCount = event.pointerCount
+    val pointerProperties = Array(pointerCount) { MotionEvent.PointerProperties() }
+    val pointerCoords = Array(pointerCount) { MotionEvent.PointerCoords() }
+
+    for (i in 0 until pointerCount) {
+      event.getPointerProperties(i, pointerProperties[i])
+      event.getPointerCoords(i, pointerCoords[i])
     }
 
-    override fun onLongPress(e: MotionEvent) {
-      onGestureEvent(mapOf("type" to "longPress", "x" to e.x, "y" to e.y))
-    }
-
-    override fun onScroll(e1: MotionEvent?, e2: MotionEvent, distanceX: Float, distanceY: Float): Boolean {
-      onGestureEvent(mapOf("type" to "scroll", "dx" to distanceX, "dy" to distanceY))
-      return true
-    }
-
-    override fun onFling(e1: MotionEvent?, e2: MotionEvent, velocityX: Float, velocityY: Float): Boolean {
-      val direction = when {
-        kotlin.math.abs(velocityX) > kotlin.math.abs(velocityY) -> if (velocityX > 0) "right" else "left"
-        else -> if (velocityY > 0) "down" else "up"
-      }
-      onGestureEvent(
+    return mapOf(
+      "action" to event.action,
+      "actionMasked" to event.actionMasked,
+      "actionIndex" to event.actionIndex,
+      "eventTime" to event.eventTime,
+      "downTime" to event.downTime,
+      "edgeFlags" to event.edgeFlags,
+      "deviceId" to event.deviceId,
+      "source" to event.source,
+      "pointerCount" to pointerCount,
+      "pointerCoords" to pointerCoords.map { coords ->
         mapOf(
-          "type" to "swipe",
-          "direction" to direction,
-          "velocity" to hypot(velocityX, velocityY)
+          "orientation" to coords.orientation,
+          "pressure" to coords.pressure,
+          "size" to coords.size,
+          "toolMajor" to coords.toolMajor,
+          "toolMinor" to coords.toolMinor,
+          "touchMajor" to coords.touchMajor,
+          "touchMinor" to coords.touchMinor,
+          "x" to coords.x,
+          "y" to coords.y
         )
-      )
-      return true
-    }
+      },
+      "pointerProperties" to pointerProperties.map { props ->
+        mapOf(
+          "id" to props.id,
+          "toolType" to props.toolType
+        )
+      },
+      "rawX" to event.rawX,
+      "rawY" to event.rawY,
+      "xPrecision" to event.xPrecision,
+      "yPrecision" to event.yPrecision,
+      "velocityX" to velocityTracker.xVelocity,
+      "velocityY" to velocityTracker.yVelocity,
+      "fps" to targetFPS
+    )
   }
 
-  private fun createEventData(event: MotionEvent): Map<String, Any> = mapOf(
-    "action" to event.action,
-    "x" to event.x,
-    "y" to event.y,
-    "pressure" to event.pressure,
-    "pointerCount" to event.pointerCount,
-    "velocityX" to velocityTracker.xVelocity,
-    "velocityY" to velocityTracker.yVelocity,
-    "timestamp" to System.currentTimeMillis(),
-    "toolType" to event.getToolType(0),
-    "orientation" to event.getAxisValue(MotionEvent.AXIS_ORIENTATION),
-    "tilt" to event.getAxisValue(MotionEvent.AXIS_TILT),
-    "fps" to targetFPS
-  )
+  // Override dispatchTouchEvent to allow child views to handle touch events
+  override fun dispatchTouchEvent(event: MotionEvent?): Boolean {
+    parent.requestDisallowInterceptTouchEvent(true)
+    handleTouchEvent(event!!)
+    return super.dispatchTouchEvent(event)
+  }
 
   override fun onDetachedFromWindow() {
     super.onDetachedFromWindow()

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,16 +1,20 @@
 import { MotionEventView } from "motion-event";
-import type { MotionEventPayload, GestureEventPayload } from "motion-event";
+import type { MotionEventPayload } from "motion-event";
 import React, { useState } from "react";
-import { Text, View, StyleSheet, TouchableOpacity } from "react-native";
+import {
+  Text,
+  View,
+  StyleSheet,
+  TouchableOpacity,
+  ScrollView,
+  Button,
+} from "react-native";
 
 const FPS_OPTIONS = [1, 30, 60, 120];
 
 export default function App() {
   const [motionEvent, setMotionEvent] = useState<MotionEventPayload | null>(
-    null,
-  );
-  const [gestureEvent, setGestureEvent] = useState<GestureEventPayload | null>(
-    null,
+    null
   );
   const [targetFPS, setTargetFPS] = useState(30);
 
@@ -18,108 +22,161 @@ export default function App() {
     setMotionEvent(event.nativeEvent);
   };
 
-  const handleGestureEvent = (event: { nativeEvent: GestureEventPayload }) => {
-    setGestureEvent(event.nativeEvent);
-  };
-
   return (
     <View style={styles.container}>
-      <View style={styles.fpsContainer}>
-        {FPS_OPTIONS.map((fps) => (
-          <TouchableOpacity
-            key={fps}
-            style={[
-              styles.fpsButton,
-              targetFPS === fps && styles.fpsButtonActive,
-            ]}
-            onPress={() => setTargetFPS(fps)}
-          >
-            <Text style={styles.fpsText}>{fps} FPS</Text>
-          </TouchableOpacity>
-        ))}
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>Motion Event Demo</Text>
+        <View style={styles.fpsContainer}>
+          {FPS_OPTIONS.map((fps) => (
+            <TouchableOpacity
+              key={fps}
+              style={[
+                styles.fpsButton,
+                targetFPS === fps && styles.fpsButtonActive,
+              ]}
+              onPress={() => setTargetFPS(fps)}
+            >
+              <Text
+                style={[
+                  styles.fpsText,
+                  targetFPS === fps && styles.fpsTextActive,
+                ]}
+              >
+                {fps} FPS
+              </Text>
+            </TouchableOpacity>
+          ))}
+        </View>
       </View>
 
-      <MotionEventView
-        style={styles.motionArea}
-        targetFPS={targetFPS}
-        onMotionEvent={handleMotionEvent}
-        onGestureEvent={handleGestureEvent}
-      />
+      <View style={styles.motionContainer}>
+        <MotionEventView
+          style={styles.motionArea}
+          targetFPS={targetFPS}
+          onMotionEvent={handleMotionEvent}
+        >
+          <Text style={styles.motionAreaText}>
+            Touch and move around this area
+          </Text>
+          <Button
+            title="Press me"
+            onPress={() => console.log("Button pressed")}
+          />
+          <Text style={styles.motionAreaSubtext}>
+            Events will be logged below
+          </Text>
+        </MotionEventView>
+      </View>
 
-      <View style={styles.eventsContainer}>
-        <Text style={styles.eventTitle}>Motion Event:</Text>
+      <ScrollView
+        style={styles.eventsContainer}
+        showsVerticalScrollIndicator={false}
+      >
+        <Text style={styles.eventTitle}>Motion Event Data:</Text>
         <Text style={styles.eventText}>
           {motionEvent
             ? JSON.stringify(motionEvent, null, 2)
             : "No motion events yet"}
         </Text>
-
-        <Text style={styles.eventTitle}>Gesture Event:</Text>
-        <Text style={styles.eventText}>
-          {gestureEvent
-            ? JSON.stringify(gestureEvent, null, 2)
-            : "No gesture events yet"}
-        </Text>
-      </View>
+      </ScrollView>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: "#f5f5f5",
+  },
   container: {
     flex: 1,
-    padding: 15,
     backgroundColor: "#f5f5f5",
+  },
+  header: {
+    padding: 20,
+    backgroundColor: "#fff",
+    borderBottomWidth: 1,
+    borderBottomColor: "#e0e0e0",
+  },
+  headerTitle: {
+    fontSize: 20,
+    fontWeight: "700",
+    color: "#1a1a1a",
+    marginBottom: 16,
   },
   fpsContainer: {
     flexDirection: "row",
-    justifyContent: "space-evenly",
-    marginBottom: 12,
+    justifyContent: "space-between",
   },
   fpsButton: {
     paddingVertical: 10,
-    paddingHorizontal: 14,
-    backgroundColor: "#ddd",
+    marginHorizontal: 4,
+    backgroundColor: "#f0f0f0",
     borderRadius: 8,
+    minWidth: 60,
+    alignItems: "center",
   },
   fpsButtonActive: {
-    backgroundColor: "#4caf50",
+    backgroundColor: "#2196F3",
   },
   fpsText: {
-    fontWeight: "bold",
+    fontSize: 12,
+    fontWeight: "600",
+    color: "#666",
+  },
+  fpsTextActive: {
     color: "#fff",
   },
+  motionContainer: {
+    padding: 20,
+  },
   motionArea: {
-    width: "100%",
     height: 200,
     backgroundColor: "#fff",
-    borderRadius: 10,
-    marginVertical: 15,
+    borderRadius: 16,
+    justifyContent: "center",
+    alignItems: "center",
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 3 },
+    shadowOpacity: 0.15,
+    shadowRadius: 6,
+    elevation: 5,
+  },
+  motionAreaText: {
+    fontSize: 18,
+    textAlign: "center",
+    color: "#666",
+    fontWeight: "500",
+    marginBottom: 8,
+  },
+  motionAreaSubtext: {
+    fontSize: 14,
+    color: "#999",
+    fontWeight: "400",
+  },
+  eventsContainer: {
+    flex: 1,
+    marginHorizontal: 20,
+    marginBottom: 20,
+    padding: 16,
+    backgroundColor: "#fff",
+    borderRadius: 16,
     shadowColor: "#000",
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.1,
     shadowRadius: 4,
     elevation: 3,
   },
-  eventsContainer: {
-    padding: 10,
-    backgroundColor: "#fff",
-    borderRadius: 10,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.1,
-    shadowRadius: 3,
-    elevation: 2,
-  },
   eventTitle: {
-    fontSize: 14,
+    fontSize: 16,
     fontWeight: "600",
-    marginVertical: 5,
+    color: "#1a1a1a",
+    marginBottom: 12,
   },
   eventText: {
-    fontSize: 12,
+    fontSize: 13,
+    lineHeight: 20,
     color: "#333",
     fontFamily: "monospace",
-    marginBottom: 10,
   },
 });

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = async (env, argv) => {
         dangerouslyAddModulePathsToTranspile: ["a"],
       },
     },
-    argv,
+    argv
   );
   config.resolve.modules = [
     path.resolve(__dirname, "./node_modules"),

--- a/src/MotionEvent.types.ts
+++ b/src/MotionEvent.types.ts
@@ -1,65 +1,49 @@
-import type { StyleProp, ViewStyle } from "react-native";
+import type { ViewProps } from "react-native";
+
+export type PointerCoords = {
+  orientation: number;
+  pressure: number;
+  size: number;
+  toolMajor: number;
+  toolMinor: number;
+  touchMajor: number;
+  touchMinor: number;
+  x: number;
+  y: number;
+};
+
+export type PointerProperties = {
+  id: number;
+  toolType: number;
+};
 
 export type MotionEventPayload = {
   action: number;
-  tilt: number;
-  x: number;
-  toolType: number;
+  actionMasked: number;
+  actionIndex: number;
+  eventTime: number;
+  downTime: number;
+  edgeFlags: number;
+  deviceId: number;
+  source: number;
   pointerCount: number;
-  pressure: number;
-  y: number;
+  pointerCoords: PointerCoords[];
+  pointerProperties: PointerProperties[];
+  rawX: number;
+  rawY: number;
+  xPrecision: number;
+  yPrecision: number;
   velocityX: number;
-  timestamp: number;
-  orientation: number;
   velocityY: number;
   fps: number;
   target: number;
 };
 
-export type GestureDirection = "up" | "down" | "left" | "right";
-
-export type SwipeGesturePayload = {
-  type: "swipe";
-  direction: GestureDirection;
-  velocity: number;
-  target: number;
-};
-
-export type LongPressGesturePayload = {
-  type: "longPress";
-  x: number;
-  y: number;
-  target: number;
-};
-
-export type TapGesturePayload = {
-  type: "tap";
-  x: number;
-  y: number;
-  target: number;
-};
-
-export type ScrollGesturePayload = {
-  type: "scroll";
-  dx: number;
-  dy: number;
-  target: number;
-};
-
-export type GestureEventPayload =
-  | SwipeGesturePayload
-  | LongPressGesturePayload
-  | TapGesturePayload
-  | ScrollGesturePayload;
-
 export type MotionEventModuleEvents = {
   onMotionEvent: (params: MotionEventPayload) => void;
-  onGestureEvent: (params: GestureEventPayload) => void;
 };
 
 export type MotionEventViewProps = {
-  onMotionEvent: (event: { nativeEvent: MotionEventPayload }) => void;
-  onGestureEvent: (event: { nativeEvent: GestureEventPayload }) => void;
+  onMotionEvent?: (event: { nativeEvent: MotionEventPayload }) => void;
   targetFPS?: number;
-  style?: StyleProp<ViewStyle>;
-};
+} & ViewProps;


### PR DESCRIPTION
Make MotionEventView to access only MotionEvent API without gestures for now, enhance fields
Allow passing children views, follow Expo guidelines
Do not intercept child's events

fix #21